### PR TITLE
printk: Refactor devkmsg_write function to remove unreachable code

### DIFF
--- a/kernel/printk/printk.c
+++ b/kernel/printk/printk.c
@@ -802,70 +802,11 @@ struct devkmsg_user {
 
 static ssize_t devkmsg_write(struct kiocb *iocb, struct iov_iter *from)
 {
-	char *buf, *line;
-	int level = default_message_loglevel;
-	int facility = 1;	/* LOG_USER */
-	struct file *file = iocb->ki_filp;
-	struct devkmsg_user *user = file->private_data;
-	size_t len = iov_iter_count(from);
-	ssize_t ret = len;
-
 	/* Don't allow userspace to write to /dev/kmesg */
+	size_t len = iov_iter_count(from);
 	return len;
-
-	if (!user || len > LOG_LINE_MAX)
-		return -EINVAL;
-
-	/* Ignore when user logging is disabled. */
-	if (devkmsg_log & DEVKMSG_LOG_MASK_OFF)
-		return len;
-#ifdef CONFIG_ODM_WT_EDIT
-//Lijie.Yang@ODM_WT.BSP.Kernel.Stability.1941873, 2020/05/21, add kernel log print limit
-	/* Ratelimit when not explicitly enabled. */
-	if (!(devkmsg_log & DEVKMSG_LOG_MASK_ON)) {
-		if (!___ratelimit(&user->rs, current->comm))
-			return ret;
-	}
-#endif /* CONFIG_ODM_WT_EDIT */
-	buf = kmalloc(len+1, GFP_KERNEL);
-	if (buf == NULL)
-		return -ENOMEM;
-
-	buf[len] = '\0';
-	if (!copy_from_iter_full(buf, len, from)) {
-		kfree(buf);
-		return -EFAULT;
-	}
-
-	/*
-	 * Extract and skip the syslog prefix <[0-9]*>. Coming from userspace
-	 * the decimal value represents 32bit, the lower 3 bit are the log
-	 * level, the rest are the log facility.
-	 *
-	 * If no prefix or no userspace facility is specified, we
-	 * enforce LOG_USER, to be able to reliably distinguish
-	 * kernel-generated messages from userspace-injected ones.
-	 */
-	line = buf;
-	if (line[0] == '<') {
-		char *endp = NULL;
-		unsigned int u;
-
-		u = simple_strtoul(line + 1, &endp, 10);
-		if (endp && endp[0] == '>') {
-			level = LOG_LEVEL(u);
-			if (LOG_FACILITY(u) != 0)
-				facility = LOG_FACILITY(u);
-			endp++;
-			len -= endp - line;
-			line = endp;
-		}
-	}
-
-	printk_emit(facility, level, NULL, 0, "%s", line);
-	kfree(buf);
-	return ret;
 }
+
 
 static ssize_t devkmsg_read(struct file *file, char __user *buf,
 			    size_t count, loff_t *ppos)


### PR DESCRIPTION
The devkmsg_write function was refactored to remove unreachable code that followed the early return statement. The original code contained unnecessary logic and checks that would never be executed due to the early return. By eliminating this redundant code, the function's execution flow is simplified and made more clear. This commit improves code readability and eliminates unnecessary computations, ensuring that the function behaves as intended without any unnecessary overhead.